### PR TITLE
Fix Yell::Event::Options

### DIFF
--- a/lib/yell/event.rb
+++ b/lib/yell/event.rb
@@ -16,6 +16,8 @@ module Yell #:nodoc:
 
 
     class Options
+      include Comparable
+
       attr_reader :severity
       attr_reader :caller_offset
 


### PR DESCRIPTION
After defining <=> it is possible to get all comparison operators for
"free" just by including the Comparable module.

This is currently needed by rails 4.2.6 and above as seen here:
https://github.com/rails/rails/commit/a2a652a512d6ee5488eb5e2d9dea310ec34e5b59#diff-8a0607141c98298ea243209f7688f9e6R51

This fixes #41 