### PR TITLE
List only CI-run Rubies as supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-before_script: gem install bundler
+before_install: gem install bundler
 script: "bundle exec rspec"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_script: gem install bundler
 script: "bundle exec rspec"
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 
 **Yell - Your Extensible Logging Library** is a comprehensive logging replacement for Ruby.
 
-Yell works and is tested with ruby 1.8.7, 1.9.x, 2.0.0, jruby 1.8 and 1.9 mode, rubinius 1.8 and 1.9 as well as ree.
+Yell works and its test suite currently runs on:
+
+- ruby-head, 2.3.1, 2.2.5, 2.2.2, 2.1.0, 2.0.0 
+- jruby-head, jruby-9.1.0.0, jruby-9.0.0.0
 
 If you want to conveniently use Yell with Rails, then head over to [yell-rails](https://github.com/rudionrails/yell-rails). You'll find all the documentation in this repository, though.
 


### PR DESCRIPTION
  - Tell only of tested support for exact versions

I don't know... This change, when I look at it, it's not so fun.

Think of it as an opener: do you want to add `required_ruby_version` to the gemspec? In v3.0.0?