### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.1.12.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html