### PR TITLE
Travis: jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.1.15.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.1.12.0
+    - rvm: jruby-9.1.13.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.0.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.1.15.0
+    - rvm: jruby-9.1.17.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       gemfile: Gemfile.lte-2.2.2
 
     - rvm: jruby-head
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
     - rvm: jruby-9.0.0.0
       gemfile: Gemfile.lte-2.2.2
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)