### PR TITLE
Update *all* hashes to >1.9 syntax + some more / closes #52

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ pkg/*
 *.gem
 .bundle
 .idea
+.vscode
 
 # bundler
 Gemfile.*lock

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ pkg/*
 .bundle
 .idea
 .vscode
-
+vendor/
 # bundler
 Gemfile.*lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ matrix:
     # ruby-head is always finicky with bundler and such
     - rvm: ruby-head
 
-#notifications:
-#  on_success: change
-#  on_failure: change
+notifications:
+  on_success: change
+  on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ matrix:
     - rvm: ruby-head
     - rvm: 2.6
     - rvm: 2.5
+    - rvm: 2.4
     - rvm: 2.3
-    - rvm: jruby-head
-    - rvm: jruby-9.1
-    - rvm: jruby-9.2
+  allow_failures:
+    # ruby-head is always finicky with bundler and such
+    - rvm: ruby-head
 
-notifications:
-  on_success: change
-  on_failure: change
+#notifications:
+#  on_success: change
+#  on_failure: change

--- a/examples/002.1-log-level-basics.rb
+++ b/examples/002.1-log-level-basics.rb
@@ -7,7 +7,7 @@ puts <<-EOS
 # Like many other logging libraries, Yell allows you to define from which level 
 # onwards you want to write your log message. 
 
-logger = Yell.new STDOUT, :level => :info
+logger = Yell.new STDOUT, level: :info
 
 logger.debug "This is a :debug message"
 #=> nil 
@@ -19,7 +19,7 @@ logger.info "This is a :info message"
 EOS
 
 puts "=== actual example ==="
-logger = Yell.new STDOUT, :level => :info
+logger = Yell.new STDOUT, level: :info
 
 logger.debug "This is a :debug message"
 logger.info "This is a :info message"

--- a/examples/002.2-log-level-on-certain-severities-only.rb
+++ b/examples/002.2-log-level-on-certain-severities-only.rb
@@ -7,10 +7,11 @@ puts <<-EOS
 # The Yell::Level parser allows you to exactly specify on which levels to log, 
 # ignoring all the others. For instance: If we want to only log at the :debug 
 # and :warn levels we simply providing an array:
+# * %i[] is a built-in for an array of symbols
 
-logger = Yell.new STDOUT, :level => [:debug, :warn]
+logger = Yell.new STDOUT, level: %i[debug warn]
 
-[:debug, :info, :warn, :error, :fatal].each do |level| 
+%i[debug info warn error fatal].each do |level| 
   logger.send( level, level )
 end
 #=> "2012-02-29T09:30:00+01:00 [DEBUG] 65784 : debug"
@@ -20,9 +21,9 @@ end
 EOS
 
 puts "=== actual example ==="
-logger = Yell.new STDOUT, :level => [:debug, :warn]
+logger = Yell.new STDOUT, level: %i[debug warn]
 
-[:debug, :info, :warn, :error, :fatal].each do |level| 
+%i[debug info warn error fatal].each do |level| 
   logger.send( level, level )
 end
 

--- a/examples/002.3-log-level-within-range.rb
+++ b/examples/002.3-log-level-within-range.rb
@@ -6,10 +6,12 @@ puts <<-EOS
 
 # Additionally to writing only on specific levels, you may pass a range to 
 # the :level option:
+# * %i[] is a built-in for an array of symbols
 
-logger = Yell.new STDOUT, :level => (:debug..:warn)
 
-[:debug, :info, :warn, :error, :fatal].each do |level| 
+logger = Yell.new STDOUT, level: (:debug..:warn)
+
+%i[debug info warn error fatal].each do |level| 
   logger.send( level, level )
 end
 #=> "2012-02-29T09:30:00+01:00 [DEBUG] 65784 : debug"
@@ -19,10 +21,10 @@ end
 
 EOS
 
-puts "=== actuale example ==="
-logger = Yell.new STDOUT, :level => (:debug..:warn)
+puts "=== actual example ==="
+logger = Yell.new STDOUT, level: (:debug..:warn)
 
-[:debug, :info, :warn, :error, :fatal].each do |level| 
+%i[debug info warn error fatal].each do |level| 
   logger.send( level, level )
 end
 

--- a/examples/003.1-formatting-DefaultFormat.rb
+++ b/examples/003.1-formatting-DefaultFormat.rb
@@ -7,7 +7,7 @@ puts <<-EOS
 # The default formatting string looks like: %d [%5L] %p : %m and is used when 
 # nothing else is defined.
 
-logger = Yell.new STDOUT, :format => Yell::DefaultFormat
+logger = Yell.new STDOUT, format: Yell::DefaultFormat
 logger.info "Hello World!"
 #=> "2012-02-29T09:30:00+01:00 [ INFO] 65784 : Hello World!"
 #    ^                         ^       ^       ^
@@ -16,7 +16,7 @@ logger.info "Hello World!"
 
 EOS
 
-puts "=== actuale example ==="
-logger = Yell.new STDOUT, :format => Yell::DefaultFormat
+puts "=== actual example ==="
+logger = Yell.new STDOUT, format: Yell::DefaultFormat
 logger.info "Hello World!"
 

--- a/examples/003.2-formatting-BasicFormat.rb
+++ b/examples/003.2-formatting-BasicFormat.rb
@@ -6,7 +6,7 @@ puts <<-EOS
 
 # The basic formating string looks like: %l, %d: %m.
 
-logger = Yell.new STDOUT, :format => Yell::BasicFormat
+logger = Yell.new STDOUT, format: Yell::BasicFormat
 logger.info "Hello World!"
 #=> "I, 2012-02-29T09:30:00+01:00 : Hello World!"
 #    ^  ^                          ^
@@ -16,7 +16,7 @@ logger.info "Hello World!"
 
 EOS
 
-puts "=== actuale example ==="
-logger = Yell.new STDOUT, :format => Yell::BasicFormat
+puts "=== actual example ==="
+logger = Yell.new STDOUT, format: Yell::BasicFormat
 logger.info "Hello World!"
 

--- a/examples/003.3-formatting-ExtendedFormat.rb
+++ b/examples/003.3-formatting-ExtendedFormat.rb
@@ -6,7 +6,7 @@ puts <<-EOS
 
 # The extended formatting string looks like: %d [%5L] %p %h : %m.
 
-logger = Yell.new STDOUT, :format => Yell::ExtendedFormat
+logger = Yell.new STDOUT, format: Yell::ExtendedFormat
 logger.info "Hello World!"
 #=> "2012-02-29T09:30:00+01:00 [ INFO] 65784 localhost : Hello World!"
 #    ^                          ^      ^     ^           ^
@@ -15,7 +15,7 @@ logger.info "Hello World!"
 
 EOS
 
-puts "=== actuale example ==="
-logger = Yell.new STDOUT, :format => Yell::ExtendedFormat
+puts "=== actual example ==="
+logger = Yell.new STDOUT, format: Yell::ExtendedFormat
 logger.info "Hello World!"
 

--- a/examples/003.4-formatting-on-your-own.rb
+++ b/examples/003.4-formatting-on-your-own.rb
@@ -6,7 +6,7 @@ puts <<-EOS
 
 # The extended formatting string looks like: %d [%5L] %p %h : %m.
 
-logger = Yell.new STDOUT, format: "[%f:%n in `%M'] %m", format: true
+logger = Yell.new STDOUT, format: "[%f:%n in `%M'] %m", trace: true
 logger.info "Hello World!"
 #=> [003.4-formatting-on-your-own.rb:20 in `<main>'] Hello World!
 #    ^                               ^      ^        ^
@@ -16,6 +16,6 @@ logger.info "Hello World!"
 EOS
 
 puts "=== actual example ==="
-logger = Yell.new STDOUT, format: "[%f:%n in `%M'] %m", format: true
+logger = Yell.new STDOUT, format: "[%f:%n in `%M'] %m", trace: true
 logger.info "Hello World!"
 

--- a/examples/003.4-formatting-on-your-own.rb
+++ b/examples/003.4-formatting-on-your-own.rb
@@ -6,7 +6,7 @@ puts <<-EOS
 
 # The extended formatting string looks like: %d [%5L] %p %h : %m.
 
-logger = Yell.new STDOUT, :format => "[%f:%n in `%M'] %m", :trace => true
+logger = Yell.new STDOUT, format: "[%f:%n in `%M'] %m", format: true
 logger.info "Hello World!"
 #=> [003.4-formatting-on-your-own.rb:20 in `<main>'] Hello World!
 #    ^                               ^      ^        ^
@@ -15,7 +15,7 @@ logger.info "Hello World!"
 
 EOS
 
-puts "=== actuale example ==="
-logger = Yell.new STDOUT, :format => "[%f:%n in `%M'] %m", :trace => true
+puts "=== actual example ==="
+logger = Yell.new STDOUT, format: "[%f:%n in `%M'] %m", format: true
 logger.info "Hello World!"
 

--- a/examples/004.1-colorizing-the-log-output.rb
+++ b/examples/004.1-colorizing-the-log-output.rb
@@ -6,7 +6,7 @@ puts <<-EOS
 
 You may colorize the log output on your io-based loggers loke so:
 
-logger = Yell.new STDOUT, :colors => true
+logger = Yell.new STDOUT, colors: true
 
 Yell::Severities.each do |level|
   logger.send level.downcase, level
@@ -14,8 +14,8 @@ end
 
 EOS
 
-puts "=== actuale example ==="
-logger = Yell.new STDOUT, :colors => true
+puts "=== actual example ==="
+logger = Yell.new STDOUT, colors: true
 
 Yell::Severities.each do |level|
   logger.send level.downcase, level

--- a/examples/005.1-repository.rb
+++ b/examples/005.1-repository.rb
@@ -7,7 +7,7 @@ puts <<-EOS
 # You can add a logger to the global repository.
 #
 # create a logger named 'mylog' that logs to stdout
-Yell.new :stdout, :name => 'mylog'
+Yell.new :stdout, name: 'mylog'
 
 # Later in the code, you can get your logger back
 Yell['mylog'].info "Hello World!"
@@ -15,7 +15,7 @@ Yell['mylog'].info "Hello World!"
 
 EOS
 
-puts "=== actuale example ==="
-Yell.new :stdout, :name => 'mylog'
+puts "=== actual example ==="
+Yell.new :stdout, name: 'mylog'
 Yell['mylog'].info "Hello World!"
 

--- a/examples/006.1-the-loggable-module.rb
+++ b/examples/006.1-the-loggable-module.rb
@@ -10,7 +10,7 @@ puts <<-EOS
 # can use it, though, you will need to define a logger providing the :name of
 # your class.
 
-Yell.new :stdout, :name => 'Foo'
+Yell.new :stdout, name: 'Foo'
 
 # Define the class
 class Foo
@@ -26,7 +26,7 @@ EOS
 
 puts "=== actual example ==="
 
-Yell.new :stdout, :name => 'Foo'
+Yell.new :stdout, name: 'Foo'
 
 class Foo
   include Yell::Loggable

--- a/examples/006.2-the-loggable-module-with-inheritance.rb
+++ b/examples/006.2-the-loggable-module-with-inheritance.rb
@@ -10,7 +10,7 @@ puts <<-EOS
 # can use it, though, you will need to define a logger providing the :name of
 # your class.
 
-Yell.new :stdout, :name => 'Foo'
+Yell.new :stdout, name: 'Foo'
 
 # Define the class
 class Foo
@@ -28,7 +28,7 @@ EOS
 
 puts "=== actual example ==="
 
-Yell.new :stdout, :name => 'Foo'
+Yell.new :stdout, name: 'Foo'
 
 class Foo
   include Yell::Loggable

--- a/lib/yell/adapters/base.rb
+++ b/lib/yell/adapters/base.rb
@@ -208,7 +208,7 @@ module Yell #:nodoc:
       # Determine whether to write at the given severity.
       #
       # @example
-      #   write? Yell::Event.new( 'INFO', 'Hwllo Wold!' )
+      #   write? Yell::Event.new( 'INFO', 'Hello Wold!' )
       #
       # @param [Yell::Event] event The log event
       #

--- a/lib/yell/adapters/datefile.rb
+++ b/lib/yell/adapters/datefile.rb
@@ -182,7 +182,7 @@ module Yell #:nodoc:
 
       # @overload inspectables
       def inspectables
-        super.concat [:date_pattern, :header, :keep, :symlink ]
+        super.concat %i[date_pattern header keep symlink]
       end
 
     end

--- a/lib/yell/adapters/datefile.rb
+++ b/lib/yell/adapters/datefile.rb
@@ -52,12 +52,12 @@ module Yell #:nodoc:
 
       # @overload setup!( options )
       def setup!( options )
-        self.header = Yell.__fetch__(options, :header, :default => true)
-        self.date_pattern = Yell.__fetch__(options, :date_pattern, :default => DefaultDatePattern)
-        self.keep = Yell.__fetch__(options, :keep, :default => false)
-        self.symlink = Yell.__fetch__(options, :symlink, :default => true)
+        self.header = Yell.__fetch__(options, :header, default: true)
+        self.date_pattern = Yell.__fetch__(options, :date_pattern, default: DefaultDatePattern)
+        self.keep = Yell.__fetch__(options, :keep, default: false)
+        self.symlink = Yell.__fetch__(options, :symlink, default: true)
 
-        @original_filename  = ::File.expand_path(Yell.__fetch__(options, :filename, :default => default_filename))
+        @original_filename  = ::File.expand_path(Yell.__fetch__(options, :filename, default: default_filename))
         options[:filename]  = @original_filename
 
         @date = Time.now

--- a/lib/yell/adapters/file.rb
+++ b/lib/yell/adapters/file.rb
@@ -9,7 +9,7 @@ module Yell #:nodoc:
 
       # @overload setup!( options )
       def setup!( options )
-        @filename = ::File.expand_path(Yell.__fetch__(options, :filename, :default => default_filename))
+        @filename = ::File.expand_path(Yell.__fetch__(options, :filename, default: default_filename))
 
         super
       end

--- a/lib/yell/adapters/io.rb
+++ b/lib/yell/adapters/io.rb
@@ -42,9 +42,9 @@ module Yell #:nodoc:
       def setup!( options )
         @stream = nil
 
-        self.colors = Yell.__fetch__(options, :colors, :default => false)
+        self.colors = Yell.__fetch__(options, :colors, default: false)
         self.formatter = Yell.__fetch__(options, :format, :formatter)
-        self.sync = Yell.__fetch__(options, :sync, :default => true)
+        self.sync = Yell.__fetch__(options, :sync, default: true)
 
         super
       end

--- a/lib/yell/formatter.rb
+++ b/lib/yell/formatter.rb
@@ -13,7 +13,7 @@ module Yell #:nodoc:
   # No format on the log message
   #
   # @example
-  #   logger = Yell.new STDOUT, :format => false
+  #   logger = Yell.new STDOUT, format: false
   #   logger.info "Hello World!"
   #   #=> "Hello World!"
   NoFormat = "%m"
@@ -21,7 +21,7 @@ module Yell #:nodoc:
   # Default Format
   #
   # @example
-  #   logger = Yell.new STDOUT, :format => Yell::DefaultFormat
+  #   logger = Yell.new STDOUT, format: Yell::DefaultFormat
   #   logger.info "Hello World!"
   #   #=> "2012-02-29T09:30:00+01:00 [ INFO] 65784 : Hello World!"
   #   #    ^                         ^       ^       ^
@@ -31,7 +31,7 @@ module Yell #:nodoc:
   # Basic Format
   #
   # @example
-  #   logger = Yell.new STDOUT, :format => Yell::BasicFormat
+  #   logger = Yell.new STDOUT, format: Yell::BasicFormat
   #   logger.info "Hello World!"
   #   #=> "I, 2012-02-29T09:30:00+01:00 : Hello World!"
   #   #    ^  ^                          ^
@@ -42,7 +42,7 @@ module Yell #:nodoc:
   # Extended Format
   #
   # @example
-  #   logger = Yell.new STDOUT, :format => Yell::ExtendedFormat
+  #   logger = Yell.new STDOUT, format: Yell::ExtendedFormat
   #   logger.info "Hello World!"
   #   #=> "2012-02-29T09:30:00+01:00 [ INFO] 65784 localhost : Hello World!"
   #   #    ^                          ^      ^     ^           ^
@@ -130,7 +130,7 @@ module Yell #:nodoc:
       end
 
       def set( key, &block )
-        @repository.merge!(key => block)
+        @repository.merge!("#{key}": block)
       end
 
       def call( message )

--- a/lib/yell/formatter.rb
+++ b/lib/yell/formatter.rb
@@ -130,7 +130,7 @@ module Yell #:nodoc:
       end
 
       def set( key, &block )
-        @repository.merge!("#{key}": block)
+        @repository.merge!(key => block)
       end
 
       def call( message )

--- a/lib/yell/helpers/adapter.rb
+++ b/lib/yell/helpers/adapter.rb
@@ -10,10 +10,10 @@ module Yell #:nodoc:
       #   adapter :file, 'development.log'
       #
       #   # Alternative notation for filename in options
-      #   adapter :file, :filename => 'developent.log'
+      #   adapter :file, filename: 'developent.log'
       #
       # @example Standard adapter with filename and additional options
-      #   adapter :file, 'development.log', :level => :warn
+      #   adapter :file, 'development.log', level: :warn
       #
       # @example Set the adapter directly from an adapter instance
       #   adapter Yell::Adapter::File.new

--- a/lib/yell/loggable.rb
+++ b/lib/yell/loggable.rb
@@ -6,7 +6,7 @@ module Yell #:nodoc:
   # provide it with the name of your class.
   #
   # @example
-  #   Yell.new :stdout, :name => 'Foo'
+  #   Yell.new :stdout, name: 'Foo'
   #
   #   class Foo
   #     include Yell::Loggable

--- a/lib/yell/logger.rb
+++ b/lib/yell/logger.rb
@@ -26,14 +26,14 @@ module Yell #:nodoc:
     #   Yell::Logger.new :datefile, 'development.log'
     #
     # @example Setting the log level
-    #   Yell::Logger.new :level => :warn
+    #   Yell::Logger.new level: :warn
     #
     #   Yell::Logger.new do |l|
     #     l.level = :warn
     #   end
     #
     # @example Combined settings
-    #   Yell::Logger.new 'development.log', :level => :warn
+    #   Yell::Logger.new 'development.log', level: :warn
     #
     #   Yell::Logger.new :datefile, 'development.log' do |l|
     #     l.level = :info
@@ -53,13 +53,13 @@ module Yell #:nodoc:
       self.formatter = Yell.__fetch__(@options, :format, :formatter)
       self.level = Yell.__fetch__(@options, :level, :default => 0)
       self.name = Yell.__fetch__(@options, :name)
-      self.trace = Yell.__fetch__(@options, :trace, :default => :error)
+      self.trace = Yell.__fetch__(@options, :trace, default: :error)
 
       # silencer
-      self.silence(*Yell.__fetch__(@options, :silence, :default => []))
+      self.silence(*Yell.__fetch__(@options, :silence, default: []))
 
       # adapters may be passed in the options
-      extract!(*Yell.__fetch__(@options, :adapters, :default => []))
+      extract!(*Yell.__fetch__(@options, :adapters, default: []))
 
       # extract adapter
       self.adapter(args.pop) if args.any?
@@ -140,7 +140,7 @@ module Yell #:nodoc:
     #   extract!(:stdout, :stderr)
     #
     # @example
-    #   extract!(:stdout => {:level => :info}, :stderr => {:level => :error})
+    #   extract!(stdout: {level: :info}, stderr: {level: :error})
     def extract!( *list )
       list.each do |a|
         if a.is_a?(Hash)

--- a/spec/yell/formatter_spec.rb
+++ b/spec/yell/formatter_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Yell::Formatter do
-  let(:logger) { Yell::Logger.new(:stdout, :name => 'Yell') }
+  let(:logger) { Yell::Logger.new(:stdout, name: 'Yell') }
   let(:message) { "Hello World!" }
   let(:event) { Yell::Event.new(logger, 1, message) }
   let(:time) { Time.now }
@@ -180,7 +180,7 @@ describe Yell::Formatter do
   end
 
   describe "Hash" do
-    let(:message) { {:test => 'message'} }
+    let(:message) { {test: 'message'} }
 
     it "Returns correctly" do
       expect(output).to eq("test: message\n")

--- a/spec/yell/level_spec.rb
+++ b/spec/yell/level_spec.rb
@@ -143,7 +143,7 @@ describe Yell::Level do
   end
 
   context "given an Array" do
-    let(:level) { Yell::Level.new( [:debug, :warn, :fatal] ) }
+    let(:level) { Yell::Level.new( %i[debug warn fatal] ) }
 
     it "should return correctly" do
       expect(level.at?(:debug)).to be_truthy

--- a/spec/yell/logger_spec.rb
+++ b/spec/yell/logger_spec.rb
@@ -71,7 +71,7 @@ describe Yell::Logger do
 
   describe "initialize with #name" do
     let(:name) { 'test' }
-    let!(:logger) { Yell.new(:name => name) }
+    let!(:logger) { Yell.new(name: name) }
 
     it "should set the name correctly" do
       expect(logger.name).to eq(name)
@@ -84,7 +84,7 @@ describe Yell::Logger do
 
   context "initialize with #level" do
     let(:level) { :error }
-    let(:logger) { Yell.new(:level => level) }
+    let(:logger) { Yell.new(level: level) }
     subject { logger.level }
 
     it { should be_instance_of(Yell::Level) }
@@ -93,7 +93,7 @@ describe Yell::Logger do
 
   context "initialize with #trace" do
     let(:trace) { :info }
-    let(:logger) { Yell.new(:trace => trace) }
+    let(:logger) { Yell.new(trace: trace) }
     subject { logger.trace }
 
     it { should be_instance_of(Yell::Level) }
@@ -102,7 +102,7 @@ describe Yell::Logger do
 
   context "initialize with #silence" do
     let(:silence) { "test" }
-    let(:logger) { Yell.new(:silence => silence) }
+    let(:logger) { Yell.new(silence: silence) }
     subject { logger.silencer }
 
     it { should be_instance_of(Yell::Silencer) }
@@ -112,7 +112,7 @@ describe Yell::Logger do
   context "initialize with a #filename" do
     it "should call adapter with :file" do
       expect(Yell::Adapters::File).to(
-        receive(:new).with(:filename => filename).and_call_original
+        receive(:new).with(filename: filename).and_call_original
       )
 
       Yell::Logger.new(filename)
@@ -124,7 +124,7 @@ describe Yell::Logger do
 
     it "should call adapter with :file" do
       expect(Yell::Adapters::File).to(
-        receive(:new).with(:filename => pathname).and_call_original
+        receive(:new).with(filename: pathname).and_call_original
       )
 
       Yell::Logger.new(pathname)
@@ -165,7 +165,7 @@ describe Yell::Logger do
 
     context "with arity" do
       let(:logger) do
-        Yell::Logger.new(:level => level) { |l| l.adapter(:stdout) }
+        Yell::Logger.new(level: level) { |l| l.adapter(:stdout) }
       end
 
       it "should pass the level correctly" do
@@ -179,7 +179,7 @@ describe Yell::Logger do
 
     context "without arity" do
       let(:logger) do
-        Yell::Logger.new(:level => level) { adapter(:stdout) }
+        Yell::Logger.new(level: level) { adapter(:stdout) }
       end
 
       it "should pass the level correctly" do
@@ -200,22 +200,22 @@ describe Yell::Logger do
       )
       expect(Yell::Adapters::Stderr).to(
         receive(:new).
-          with(hash_including(:level => :error)).
+          with(hash_including(level: :error)).
           and_call_original
       )
 
       Yell::Logger.new(
-        :adapters => [
+        adapters: [
           :stdout,
-          {:stderr => {:level => :error}}
+          {stderr: {level: :error}}
         ]
       )
     end
   end
 
   context "caller's :file, :line and :method" do
-    let(:stdout) { Yell::Adapters::Stdout.new(:format => "%F, %n: %M") }
-    let(:logger) { Yell::Logger.new(:trace => true) { |l| l.adapter(stdout) } }
+    let(:stdout) { Yell::Adapters::Stdout.new(format: "%F, %n: %M") }
+    let(:logger) { Yell::Logger.new(trace: true) { |l| l.adapter(stdout) } }
 
     it "should write correctly" do
       factory = LoggerFactory.new
@@ -234,7 +234,7 @@ describe Yell::Logger do
   end
 
   context "logging in general" do
-    let(:logger) { Yell::Logger.new(filename, :format => "%m") }
+    let(:logger) { Yell::Logger.new(filename, format: "%m") }
     let(:line) { File.open(filename, &:readline) }
 
     it "should output a single message" do
@@ -244,19 +244,19 @@ describe Yell::Logger do
     end
 
     it "should output multiple messages" do
-      logger.info ["Hello", "W", "o", "r", "l", "d"]
-
+      # logger.info ["Hello", "W", "o", "r", "l", "d"]
+      logger.info %w[Hello W o r l d]
       expect(line).to eq("Hello W o r l d\n")
     end
 
     it "should output a hash and message" do
-      logger.info ["Hello World", {:test => :message}]
+      logger.info ["Hello World", {test: :message}]
 
       expect(line).to eq("Hello World test: message\n")
     end
 
     it "should output a hash and message" do
-      logger.info [{:test => :message}, "Hello World"]
+      logger.info [{test: :message}, "Hello World"]
 
       expect(line).to eq("test: message Hello World\n")
     end
@@ -271,7 +271,7 @@ describe Yell::Logger do
   context "logging with a silencer" do
     let(:silence) { "this" }
     let(:stdout) { Yell::Adapters::Stdout.new }
-    let(:logger) { Yell::Logger.new(stdout, :silence => silence) }
+    let(:logger) { Yell::Logger.new(stdout, silence: silence) }
 
     it "should not pass a matching message to any adapter" do
       expect(stdout).to_not receive(:write)

--- a/spec/yell/repository_spec.rb
+++ b/spec/yell/repository_spec.rb
@@ -70,7 +70,7 @@ describe Yell::Repository do
   end
 
   context "loggers" do
-    let(:loggers) { { name: logger } }
+    let(:loggers) { { name => logger } }
     subject { Yell::Repository.loggers }
     before { Yell::Repository[name] = logger }
 

--- a/spec/yell/repository_spec.rb
+++ b/spec/yell/repository_spec.rb
@@ -12,7 +12,7 @@ describe Yell::Repository do
     end
 
     context "when logger with :name exists" do
-      let!(:logger) { Yell.new(:stdout, :name => name) }
+      let!(:logger) { Yell.new(:stdout, name: name) }
 
       it "should eq(logger)" do
         expect(subject).to eq(logger)
@@ -20,7 +20,7 @@ describe Yell::Repository do
     end
 
     context "given a Class" do
-      let!(:logger) { Yell.new(:stdout, :name => "Numeric") }
+      let!(:logger) { Yell.new(:stdout, name: "Numeric") }
 
       it "should raise with the correct :name when logger not found" do
         expect(Yell::LoggerNotFound).to(
@@ -50,7 +50,7 @@ describe Yell::Repository do
   end
 
   context ".[]= with a named logger" do
-    let!(:logger) { Yell.new(:stdout, :name => name) }
+    let!(:logger) { Yell.new(:stdout, name: name) }
     before { Yell::Repository[name] = logger }
 
     it "should eq(logger)" do
@@ -60,7 +60,7 @@ describe Yell::Repository do
 
   context ".[]= with a named logger of a different name" do
     let(:other) { 'other' }
-    let(:logger) { Yell.new(:stdout, :name => other) }
+    let(:logger) { Yell.new(:stdout, name: other) }
     before { Yell::Repository[name] = logger }
 
     it "should add logger to both repositories" do
@@ -70,7 +70,7 @@ describe Yell::Repository do
   end
 
   context "loggers" do
-    let(:loggers) { { name => logger } }
+    let(:loggers) { { name: logger } }
     subject { Yell::Repository.loggers }
     before { Yell::Repository[name] = logger }
 

--- a/yell.gemspec
+++ b/yell.gemspec
@@ -12,7 +12,17 @@ Gem::Specification.new do |spec|
   spec.homepage    = "http://rudionrailspec.github.com/yell"
   spec.summary     = %q{Yell - Your Extensible Logging Library}
   spec.description = %q{Yell - Your Extensible Logging Library. Define multiple adapters, various log level combinations or message formatting options like you've never done before}
-
+  if spec.respond_to?(:metadata)
+    # metadata keys must be strings, not symbols
+    spec.metadata = {
+      'github_repo'       => 'https://github.com/rudionrails/yell',
+      'bug_tracker_uri'   => 'https://github.com/rudionrails/yell/issues',
+      'documentation_uri' => 'http://rudionrailspec.github.com/yell',
+      'homepage_uri'      => 'http://rudionrailspec.github.com/yell',
+      'source_code_uri'   => 'https://github.com/rudionrails/yell',
+      'wiki_uri'          => 'http://rudionrailspec.github.com/yell'
+    } 
+  end
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/yell.gemspec
+++ b/yell.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.summary     = %q{Yell - Your Extensible Logging Library}
   spec.description = %q{Yell - Your Extensible Logging Library. Define multiple adapters, various log level combinations or message formatting options like you've never done before}
 
-  spec.rubyforge_project = "yell"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
* This updates _all_ hashes to the >1.9 syntax
* Fixes some misspellings in 'Hello World' and 'actual' which were 'Hellw World' and 'actuale' respectively.
* Spec's have also been quickly gone through and been updated to >1.9 syntax
* arrays of symbols have been quickly skimmed and converted to %i[] syntax
   * formatter_spec.rb :heavy_check_mark:
   * level_spec.rb :heavy_check_mark: 
   * logger_spec.rb :heavy_check_mark: 
      * used %w[] syntax for line 246 'should output multiple messages'
   * repository_spec.rb :heavy_check_mark: 

* removed rubyforge from gemspec since rubyforge is dead
* updated .gitignore with '.vscode'
* add some metadata to the gemspec for rubygems.org
