### PR TITLE
Drop native tainting feature and use an attribute

### DIFF
--- a/lib/yell/level.rb
+++ b/lib/yell/level.rb
@@ -41,6 +41,7 @@ module Yell #:nodoc:
     #
     # @param [Integer,String,Symbol,Array,Range,nil] severity The severity for the level.
     def initialize( *severities )
+      @tainted = false
       set(*severities)
     end
 
@@ -176,7 +177,7 @@ module Yell #:nodoc:
       else set!( index ) # :==
       end
 
-      taint unless tainted?
+      @tainted = true unless @tainted
     end
 
     def index_from( severity )
@@ -203,7 +204,7 @@ module Yell #:nodoc:
     end
 
     def set!( index, val = true )
-      @severities.map! { false } unless tainted?
+      @severities.map! { false } unless @tainted
 
       @severities[index] = val
     end


### PR DESCRIPTION
Ruby 2.7 dropped the support of tainting, so we can't use it anymore -
https://bugs.ruby-lang.org/issues/16131

Easiest fix is to use a variable for it.

Related to https://github.com/rudionrails/yell/issues/57