### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 before_install: gem install bundler
 script: "bundle exec rspec"
 
+cache: bundler
+
 matrix:
   include:
     - rvm: ruby-head


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled on Travis. Thank you.